### PR TITLE
Support for proxied flag

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -95,7 +95,7 @@ function add(rr, options) {
   var zid = rr.zoneId;
 
   var uri = join('zones', zid, 'dns_records');
-  var body = pick(rr.toJSON({useAliases: true}), ['type', 'name', 'content', 'ttl']);
+  var body = pick(rr.toJSON({useAliases: true}), ['type', 'name', 'content', 'ttl', 'proxied']);
   options.method = 'POST';
   options.body = JSON.stringify(body);
 


### PR DESCRIPTION
Regards #6 and #13, as your support wrote to me this morning

Ticket https://support.cloudflare.com/hc/requests/1194233 (funny some ticket links doesn't work)

```
Eden Wee (CloudFlare)
Sep 16, 5:16 AM BST

Hi,

I tried with this and it creates a new DNS record with CloudFlare services enabled (Orange Clouded):

curl -X POST "https://api.cloudflare.com/client/v4/zones/zone_id/dns_records" \
-H "X-Auth-Email: email@address.com" \
-H "X-Auth-Key: api_key" \
-H "Content-Type: application/json" \
--data '{"type":"A","name":"example.com","content":"1.1.1.1","ttl":1,"proxied":true}'
Thank you
Eden

```