### PR TITLE
Add priority for MX records

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -99,10 +99,14 @@ function add(rr, options) {
   var zid = rr.zoneId;
 
   var uri = join('zones', zid, 'dns_records');
-  var body = pick(rr.toJSON({useAliases: true}), ['type', 'name', 'content', 'ttl', 'proxied']);
-  if (body.type === 'MX') {
-    body.priority = rr.priority;
+  var fields = ['type', 'name', 'content', 'ttl', 'proxied'];
+  if (rr.type === 'MX') {
+    fields.push('priority');
+  } else if (rr.type === 'SRV') {
+    fields = ['type', 'data'];
   }
+  var body = pick(rr.toJSON({useAliases: true}), fields);
+
   options.method = 'POST';
   options.body = JSON.stringify(body);
 

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -28,6 +28,10 @@ var DNSRecord = new verymodel.Model({
   }, default: function () {
     return new Date();
   }, static: true},
+  priority: {
+    type: 'integer',
+    default: 0
+  },
   data: {},
   meta: {}
 });
@@ -96,6 +100,9 @@ function add(rr, options) {
 
   var uri = join('zones', zid, 'dns_records');
   var body = pick(rr.toJSON({useAliases: true}), ['type', 'name', 'content', 'ttl', 'proxied']);
+  if (body.type === 'MX') {
+    body.priority = rr.priority;
+  }
   options.method = 'POST';
   options.body = JSON.stringify(body);
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "nock": "^8.0.0",
     "nyc": "^8.0.0",
     "semantic-release": "^4.3.5",
+    "sinon": "^1.17.6",
     "xo": "^0.16.0"
   },
   "homepage": "https://github.com/cloudflare/node-cloudflare",

--- a/test/dns.js
+++ b/test/dns.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import test from 'ava';
 import nock from 'nock';
+import sinon from 'sinon';
 import CF, {DNSRecord, PaginatedResponse, Zone} from '../';
 
 nock.disableNetConnect();
@@ -246,6 +247,28 @@ test('create SRV record', async t => {
   t.true(record.data.name === 'a');
 });
 
+test('passes only type and data for SRV record creation', async t => {
+  const rr = DNSRecord.create({
+    zone_id: '1',
+    type: 'SRV',
+    name: 'something',
+    content: 'random content',
+    data: {
+      name: 'a'
+    }
+  });
+  const cf = t.context.cf;
+  const fakeGot = sinon.stub(cf, '_got').returns(Promise.resolve({
+    body: {
+      result: rr.toJSON()
+    }
+  }));
+  await t.context.cf.addDNS(rr);
+  const body = JSON.parse(fakeGot.getCall(0).args[1].body);
+  // Should only have type and data as keys, even though more data was passed to DNSRecord constructor
+  t.deepEqual(Object.keys(body).sort(), ['data', 'type'], 'Incorrect values present in body');
+});
+
 test('create MX record without priority - defaults to 0', async t => {
   const rr = DNSRecord.create({
     zone_id: '1',
@@ -263,7 +286,27 @@ test('create MX record without priority - defaults to 0', async t => {
       }
     });
   let record = await t.context.cf.addDNS(rr);
-  t.true(record.priority === 0);
+  t.is(record.priority, 0);
+});
+
+test('creating MX record includes priority in body', async t => {
+  const rr = DNSRecord.create({
+    zone_id: '1',
+    type: 'MX',
+    name: 'something.com',
+    ttl: 100
+  });
+  const cf = t.context.cf;
+  const fakeGot = sinon.stub(cf, '_got').returns(Promise.resolve({
+    body: {
+      result: rr.toJSON()
+    }
+  }));
+  await t.context.cf.addDNS(rr);
+  // Re-read body from the _got call
+  const body = JSON.parse(fakeGot.getCall(0).args[1].body);
+  // Should include priority even if not provided in rr
+  t.is(body.priority, 0);
 });
 
 test('create MX record with priority', async t => {
@@ -274,15 +317,15 @@ test('create MX record with priority', async t => {
     ttl: 100,
     priority: 50
   });
-  nock('https://api.cloudflare.com')
-    .post('/client/v4/zones/1/dns_records')
-    .reply(200, {
-      result: {
-        id: '12345',
-        type: 'MX',
-        priority: rr.priority
-      }
-    });
-  let record = await t.context.cf.addDNS(rr);
-  t.true(record.priority === 50);
+  const cf = t.context.cf;
+  const fakeGot = sinon.stub(cf, '_got').returns(Promise.resolve({
+    body: {
+      result: rr.toJSON()
+    }
+  }));
+  await t.context.cf.addDNS(rr);
+  // Re-read body from the _got call
+  const body = JSON.parse(fakeGot.getCall(0).args[1].body);
+  // Should have the priority provided to rr
+  t.is(body.priority, 50);
 });

--- a/test/dns.js
+++ b/test/dns.js
@@ -1,7 +1,6 @@
 /* eslint-disable camelcase */
 import test from 'ava';
 import nock from 'nock';
-import sinon from 'sinon';
 import CF, {DNSRecord, PaginatedResponse, Zone} from '../';
 
 nock.disableNetConnect();
@@ -247,28 +246,6 @@ test('create SRV record', async t => {
   t.true(record.data.name === 'a');
 });
 
-test('passes only type and data for SRV record creation', async t => {
-  const rr = DNSRecord.create({
-    zone_id: '1',
-    type: 'SRV',
-    name: 'something',
-    content: 'random content',
-    data: {
-      name: 'a'
-    }
-  });
-  const cf = t.context.cf;
-  const fakeGot = sinon.stub(cf, '_got').returns(Promise.resolve({
-    body: {
-      result: rr.toJSON()
-    }
-  }));
-  await t.context.cf.addDNS(rr);
-  const body = JSON.parse(fakeGot.getCall(0).args[1].body);
-  // Should only have type and data as keys, even though more data was passed to DNSRecord constructor
-  t.deepEqual(Object.keys(body).sort(), ['data', 'type'], 'Incorrect values present in body');
-});
-
 test('create MX record without priority - defaults to 0', async t => {
   const rr = DNSRecord.create({
     zone_id: '1',
@@ -289,26 +266,6 @@ test('create MX record without priority - defaults to 0', async t => {
   t.is(record.priority, 0);
 });
 
-test('creating MX record includes priority in body', async t => {
-  const rr = DNSRecord.create({
-    zone_id: '1',
-    type: 'MX',
-    name: 'something.com',
-    ttl: 100
-  });
-  const cf = t.context.cf;
-  const fakeGot = sinon.stub(cf, '_got').returns(Promise.resolve({
-    body: {
-      result: rr.toJSON()
-    }
-  }));
-  await t.context.cf.addDNS(rr);
-  // Re-read body from the _got call
-  const body = JSON.parse(fakeGot.getCall(0).args[1].body);
-  // Should include priority even if not provided in rr
-  t.is(body.priority, 0);
-});
-
 test('create MX record with priority', async t => {
   const rr = DNSRecord.create({
     zone_id: '1',
@@ -317,15 +274,15 @@ test('create MX record with priority', async t => {
     ttl: 100,
     priority: 50
   });
-  const cf = t.context.cf;
-  const fakeGot = sinon.stub(cf, '_got').returns(Promise.resolve({
-    body: {
-      result: rr.toJSON()
+  nock('https://api.cloudflare.com')
+  .post('/client/v4/zones/1/dns_records')
+  .reply(200, {
+    result: {
+      id: '12345',
+      type: 'MX',
+      priority: rr.priority
     }
-  }));
-  await t.context.cf.addDNS(rr);
-  // Re-read body from the _got call
-  const body = JSON.parse(fakeGot.getCall(0).args[1].body);
-  // Should have the priority provided to rr
-  t.is(body.priority, 50);
+  });
+  let record = await t.context.cf.addDNS(rr);
+  t.is(record.priority, 50);
 });

--- a/test/dns.js
+++ b/test/dns.js
@@ -225,6 +225,27 @@ test('delete DNS Record', async t => {
   t.true(record.id === '80808');
 });
 
+test('create SRV record', async t => {
+  const rr = DNSRecord.create({
+    zone_id: '1',
+    type: 'SRV',
+    data: {
+      name: 'a'
+    }
+  });
+  nock('https://api.cloudflare.com')
+    .post('/client/v4/zones/1/dns_records')
+    .reply(200, {
+      result: {
+        id: '12345',
+        type: 'SRV',
+        data: rr.data
+      }
+    });
+  let record = await t.context.cf.addDNS(rr);
+  t.true(record.data.name === 'a');
+});
+
 test('create MX record without priority - defaults to 0', async t => {
   const rr = DNSRecord.create({
     zone_id: '1',

--- a/test/dns.js
+++ b/test/dns.js
@@ -224,3 +224,44 @@ test('delete DNS Record', async t => {
   t.false(DNSRecord.is(record));
   t.true(record.id === '80808');
 });
+
+test('create MX record without priority - defaults to 0', async t => {
+  const rr = DNSRecord.create({
+    zone_id: '1',
+    type: 'MX',
+    name: 'something.com',
+    ttl: 100
+  });
+  nock('https://api.cloudflare.com')
+    .post('/client/v4/zones/1/dns_records')
+    .reply(200, {
+      result: {
+        id: '12345',
+        type: 'MX',
+        priority: rr.priority
+      }
+    });
+  let record = await t.context.cf.addDNS(rr);
+  t.true(record.priority === 0);
+});
+
+test('create MX record with priority', async t => {
+  const rr = DNSRecord.create({
+    zone_id: '1',
+    type: 'MX',
+    name: 'something.com',
+    ttl: 100,
+    priority: 50
+  });
+  nock('https://api.cloudflare.com')
+    .post('/client/v4/zones/1/dns_records')
+    .reply(200, {
+      result: {
+        id: '12345',
+        type: 'MX',
+        priority: rr.priority
+      }
+    });
+  let record = await t.context.cf.addDNS(rr);
+  t.true(record.priority === 50);
+});


### PR DESCRIPTION
Issue:
Without priority in body, adding MX returns
```
{ code: 9008,
    message: 'Invalid priority, priority must be set and be between 0 and 65535' }
```

This PR adds the priority on the `verymodel` and picks it only for MX records.
It defaults to 0 if not provided.