### PR TITLE
Small spelling mistakes in docs

### DIFF
--- a/lib/resources/ZoneSettings.js
+++ b/lib/resources/ZoneSettings.js
@@ -64,7 +64,7 @@ module.exports = auto(
      * @returns {Promise<Object>} The zone settings response object.
      */
     /**
-     * edit modifies a single zoen setting
+     * edit modifies a single zone setting
      *
      * @function edit
      * @memberof ZoneSettings
@@ -72,7 +72,7 @@ module.exports = auto(
      * @async
      * @param {string} id - The zone ID
      * @param {string} setting = The setting name
-     * @param {sting|Object} value - The new zone setting
+     * @param {string|Object} value - The new zone setting
      * @returns {Promise<Object>} The zone settings response object.
      */
   })


### PR DESCRIPTION
Fixes two minor spelling mistakes in the JSdocs.