### PR TITLE
fixed bug where entire application would fail, in cases where process.versions is undefined

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -54,7 +54,7 @@ module.exports = prototypal({
       method: requestMethod,
       headers: {
         'user-agent': `cloudflare/${pkg.version} node/${process.versions.node ||
-           ''}`,
+          ''}`,
         'Content-Type': opts.contentType || 'application/json',
         Accept: 'application/json',
         'X-Cloudflare-Client-User-Agent': USER_AGENT,

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -53,7 +53,7 @@ module.exports = prototypal({
       retries: opts.retries,
       method: requestMethod,
       headers: {
-        'user-agent': `cloudflare/${pkg.version} node/${process.versions.node}`,
+        'user-agent': `cloudflare/${pkg.version} node/${process.versions.node || ''}`,
         'Content-Type': opts.contentType || 'application/json',
         Accept: 'application/json',
         'X-Cloudflare-Client-User-Agent': USER_AGENT,

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -53,7 +53,8 @@ module.exports = prototypal({
       retries: opts.retries,
       method: requestMethod,
       headers: {
-        'user-agent': `cloudflare/${pkg.version} node/${process.versions.node || ''}`,
+        'user-agent': `cloudflare/${pkg.version} node/${process.versions.node ||
+           ''}`,
         'Content-Type': opts.contentType || 'application/json',
         Accept: 'application/json',
         'X-Cloudflare-Client-User-Agent': USER_AGENT,


### PR DESCRIPTION
In web applications such as Vue.js, process.versions is not available.
This causes the entire application to crash.
Here's an easy fix, but feel free to suggest a better solution.