### PR TITLE
Request: move DefinitelyTyped definitions directly into library

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,295 @@
+// Type definitions for cloudflare 2.7
+// Project: https://github.com/cloudflare/node-cloudflare
+// Definitions by: Samuel Corsi-House <https://github.com/Xenfo>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.3
+
+declare namespace Cloudflare {
+  type RecordTypes =
+    | "A"
+    | "AAAA"
+    | "CNAME"
+    | "HTTPS"
+    | "TXT"
+    | "SRV"
+    | "LOC"
+    | "MX"
+    | "NS"
+    | "SPF"
+    | "CERT"
+    | "DNSKEY"
+    | "DS"
+    | "NAPTR"
+    | "SMIMEA"
+    | "SSHFP"
+    | "SVCB"
+    | "TLSA"
+    | "URI read only";
+
+  type ResponseObjectPromise = Promise<object>;
+
+  interface AuthObject {
+    email?: string;
+    key?: string;
+    token?: string;
+  }
+
+  interface DNSRecords {
+    edit(
+      zone_id: string,
+      id: string,
+      record: {
+        type: RecordTypes;
+        name: string;
+        content: string;
+        ttl: number;
+        proxied?: boolean;
+      },
+    ): ResponseObjectPromise;
+    browse(zone_id: string): ResponseObjectPromise;
+    export(zone_id: string): ResponseObjectPromise;
+    del(zone_id: string, id: string): ResponseObjectPromise;
+    read(zone_id: string, id: string): ResponseObjectPromise;
+    add(
+      zone_id: string,
+      record: {
+        type: RecordTypes;
+        name: string;
+        content: string;
+        ttl: number;
+        priority: number;
+        proxied?: boolean;
+      },
+    ): ResponseObjectPromise;
+  }
+
+  interface EnterpriseZoneWorkerScripts {
+    read(account_id: string, name: string): ResponseObjectPromise;
+    browse(account_id: string, name: string): ResponseObjectPromise;
+    edit(account_id: string, name: string, script: string): ResponseObjectPromise;
+    del(account_id: string, name: string): ResponseObjectPromise;
+  }
+
+  interface EnterpriseZoneWorkersRoutes {
+    browse(zone_id: string): ResponseObjectPromise;
+    del(zone_id: string, id: string): ResponseObjectPromise;
+    add(zone_id: string, config: { pattern: string; script: string }): ResponseObjectPromise;
+    edit(zone_id: string, id: string, config: { pattern: string; script: string }): ResponseObjectPromise;
+    read(zone_id: string, id: string): ResponseObjectPromise;
+  }
+
+  interface EnterpriseZoneWorkersKVNamespaces {
+    edit(account_id: string, id: string, config: { title: string }): ResponseObjectPromise;
+    browse(account_id: string): ResponseObjectPromise;
+    add(account_id: string, config: { title: string }): ResponseObjectPromise;
+    del(account_id: string, id: string): ResponseObjectPromise;
+  }
+
+  interface EnterpriseZoneWorkersKV {
+    browse(account_id: string, namespace_id: string): ResponseObjectPromise;
+    add(account_id: string, namespace_id: string, value: string): ResponseObjectPromise;
+    read(account_id: string, namespace_id: string, key_name: string): ResponseObjectPromise;
+    del(account_id: string, namespace_id: string, key_name: string): ResponseObjectPromise;
+    addMulti(
+      account_id: string,
+      namespace_id: string,
+      data: Array<{ pattern: string; script: string }>,
+    ): ResponseObjectPromise;
+    delMulti(account_id: string, namespace_id: string, data: string[]): ResponseObjectPromise;
+  }
+
+  interface CFIPs {
+    browse(): ResponseObjectPromise;
+  }
+
+  interface PageRules {
+    edit(
+      id: string,
+      page_rule: {
+        tragets: [
+          {
+            target: string;
+            constraint: {
+              operator: string;
+              value: string;
+            };
+          },
+        ];
+        actions: [
+          {
+            id: string;
+            value: string;
+          },
+        ];
+        priority?: number;
+        status?: string;
+      },
+    ): ResponseObjectPromise;
+    add(zone: {
+      tragets: [
+        {
+          target: string;
+          constraint: {
+            operator: string;
+            value: string;
+          };
+        },
+      ];
+      actions: [
+        {
+          id: string;
+          value: string;
+        },
+      ];
+      priority?: number;
+      status?: string;
+    }): ResponseObjectPromise;
+    del(id: string): ResponseObjectPromise;
+    browse(): ResponseObjectPromise;
+    read(id: string): ResponseObjectPromise;
+  }
+
+  interface Zones {
+    activationCheck(id: string): ResponseObjectPromise;
+    del(id: string): ResponseObjectPromise;
+    add(zone: {
+      name: string;
+      action: { id: string };
+      jump_start?: boolean;
+      type?: "full" | "partial";
+    }): ResponseObjectPromise;
+    edit(
+      id: string,
+      zone: {
+        name: string;
+        action: { id: string };
+        jump_start?: boolean;
+        type?: "full" | "partial";
+      },
+    ): ResponseObjectPromise;
+    read(id: string): ResponseObjectPromise;
+    purgeCache(
+      id: string,
+      params: {
+        files?:
+        | string[]
+        | { url: string; headers: { Origin: string; "CF-IPCountry": string; "CF-Device-Type": string } };
+        tags?: string[];
+        hosts?: string[];
+        prefixes?: string[];
+      },
+    ): ResponseObjectPromise;
+    browse(): ResponseObjectPromise;
+  }
+
+  interface ZoneSettings {
+    read(id: string, setting: string): ResponseObjectPromise;
+    edit(id: string, setting: string, value: string | Record<string, unknown>): ResponseObjectPromise;
+    editAll(id: string, settings: any): ResponseObjectPromise;
+    browse(id: string): ResponseObjectPromise;
+  }
+
+  interface ZoneCustomHostNames {
+    browse(zone_id: string): ResponseObjectPromise;
+    read(zone_id: string, id: string): ResponseObjectPromise;
+    edit(
+      zone_id: string,
+      id: string,
+      config: {
+        hostname: string;
+        ssl: {
+          method: string;
+          type: string;
+          settings: {
+            http2: string;
+            http3: string;
+            min_tls_version: string;
+            tls_1_3: string;
+            ciphers: string[];
+          };
+          bundle_method: string;
+          wildcard: boolean;
+          custom_certificate: string;
+          custom_key: string;
+        };
+      },
+    ): ResponseObjectPromise;
+    add(
+      zone_id: string,
+      config: {
+        hostname: string;
+        ssl: {
+          method: string;
+          type: string;
+          settings: {
+            http2: string;
+            http3: string;
+            min_tls_version: string;
+            tls_1_3: string;
+            ciphers: string[];
+          };
+          bundle_method: string;
+          wildcard: boolean;
+          custom_certificate: string;
+          custom_key: string;
+        };
+      },
+    ): ResponseObjectPromise;
+    del(zone_id: string, id: string): ResponseObjectPromise;
+  }
+
+  interface ZoneWorkers {
+    validate(zone_id: string, script: string): ResponseObjectPromise;
+  }
+
+  interface ZoneWorkersScript {
+    read(zone_id: string, script?: string): ResponseObjectPromise;
+    del(): ResponseObjectPromise;
+  }
+
+  interface ZoneWorkersRoutes {
+    browse(zone_id: string): ResponseObjectPromise;
+    edit(zone_id: string, id: string, config: { pattern: string; script: string }): ResponseObjectPromise;
+    read(zone_id: string, id: string): ResponseObjectPromise;
+    add(zone_id: string, config: { pattern: string; script: string }): ResponseObjectPromise;
+    del(zone_id: string, id: string): ResponseObjectPromise;
+  }
+
+  interface User {
+    read(): ResponseObjectPromise;
+    edit(user: {
+      first_name: string;
+      last_name: string;
+      telephone: string;
+      country: string;
+      zipcode: string;
+    }): ResponseObjectPromise;
+  }
+
+  interface Stream {
+    listVideos(accountId: string): ResponseObjectPromise;
+    videoDetails(accountId: string, id: string): ResponseObjectPromise;
+    deleteVideo(accountId: string, id: string): ResponseObjectPromise;
+  }
+}
+
+declare class Cloudflare {
+  constructor(auth: Cloudflare.AuthObject);
+
+  dnsRecords: Cloudflare.DNSRecords;
+  enterpriseZoneWorkersScripts: Cloudflare.EnterpriseZoneWorkerScripts;
+  enterpriseZoneWorkersRoutes: Cloudflare.EnterpriseZoneWorkersRoutes;
+  enterpriseZoneWorkersKVNamespaces: Cloudflare.EnterpriseZoneWorkersKVNamespaces;
+  enterpriseZoneWorkersKV: Cloudflare.EnterpriseZoneWorkersKV;
+  ips: Cloudflare.CFIPs;
+  zones: Cloudflare.Zones;
+  zoneSettings: Cloudflare.ZoneSettings;
+  zoneCustomHostNames: Cloudflare.ZoneCustomHostNames;
+  zoneWorkers: Cloudflare.ZoneWorkers;
+  zoneWorkersScript: Cloudflare.ZoneWorkersScript;
+  zoneWorkersRoutes: Cloudflare.ZoneWorkersRoutes;
+  user: Cloudflare.User;
+  stream: Cloudflare.Stream;
+}
+
+export = Cloudflare;

--- a/index.d.ts
+++ b/index.d.ts
@@ -177,6 +177,7 @@ declare namespace Cloudflare {
         tags?: string[];
         hosts?: string[];
         prefixes?: string[];
+        purge_everything?: boolean;
       },
     ): ResponseObjectPromise;
     browse(): ResponseObjectPromise;

--- a/index.d.ts
+++ b/index.d.ts
@@ -104,9 +104,10 @@ declare namespace Cloudflare {
 
   interface PageRules {
     edit(
+      zone_id: string, 
       id: string,
       page_rule: {
-        tragets: [
+        targets: [
           {
             target: string;
             constraint: {
@@ -125,8 +126,8 @@ declare namespace Cloudflare {
         status?: string;
       },
     ): ResponseObjectPromise;
-    add(zone: {
-      tragets: [
+    add(zone_id: string, zone: {
+      targets: [
         {
           target: string;
           constraint: {
@@ -144,9 +145,9 @@ declare namespace Cloudflare {
       priority?: number;
       status?: string;
     }): ResponseObjectPromise;
-    del(id: string): ResponseObjectPromise;
-    browse(): ResponseObjectPromise;
-    read(id: string): ResponseObjectPromise;
+    del(zone_id: string, id: string): ResponseObjectPromise;
+    browse(zone_id: string): ResponseObjectPromise;
+    read(zone_id: string, id: string): ResponseObjectPromise;
   }
 
   interface Zones {
@@ -283,6 +284,7 @@ declare class Cloudflare {
   enterpriseZoneWorkersKVNamespaces: Cloudflare.EnterpriseZoneWorkersKVNamespaces;
   enterpriseZoneWorkersKV: Cloudflare.EnterpriseZoneWorkersKV;
   ips: Cloudflare.CFIPs;
+  pageRules: Cloudflare.PageRules;
   zones: Cloudflare.Zones;
   zoneSettings: Cloudflare.ZoneSettings;
   zoneCustomHostNames: Cloudflare.ZoneCustomHostNames;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   ],
   "license": "MIT",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cloudflare/node-cloudflare.git"
@@ -52,6 +53,7 @@
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "lib"
   ],
   "xo": {


### PR DESCRIPTION
Reasons for doing so:

- Removes the need to separately install type definitions as a TypeScript user.
- The type definitions for [@types/cloudflare](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/cloudflare/index.d.ts) are a little outdated, and include some typos / broken definitions.

I will continue testing and improving upon these types if this is something the maintainers are interested in merging in.

Thanks