### PR TITLE
EnterpriseZoneWorkersKV.add: add missing key_name

### DIFF
--- a/lib/resources/EnterpriseZoneWorkersKV.js
+++ b/lib/resources/EnterpriseZoneWorkersKV.js
@@ -49,6 +49,7 @@ module.exports = auto(
      * @async
      * @param {string} account_id - The account ID
      * @param {string} namespace_id - The namespace ID
+     * @param {string} key_name - The key name
      * @param {string} value - The value to store
      * @returns {Promise<Object>} The KV response object
      */

--- a/lib/resources/EnterpriseZoneWorkersKV.js
+++ b/lib/resources/EnterpriseZoneWorkersKV.js
@@ -55,7 +55,7 @@ module.exports = auto(
      */
     add: method({
       method: 'PUT',
-      path: 'values/:id',
+      path: 'values/:key_name',
     }),
     /**
      * read allows for reading the contents of key in a namespace
@@ -71,7 +71,7 @@ module.exports = auto(
      */
     read: method({
       method: 'GET',
-      path: 'values/:id',
+      path: 'values/:key_name',
       json: false,
       contentType: 'text/plain',
     }),
@@ -89,7 +89,7 @@ module.exports = auto(
      */
     del: method({
       method: 'DELETE',
-      path: 'values/:id',
+      path: 'values/:key_name',
     }),
     /**
      * addMulti allows for creating multiple key-value pairs in a namespace

--- a/lib/resources/EnterpriseZoneWorkersKV.js
+++ b/lib/resources/EnterpriseZoneWorkersKV.js
@@ -49,7 +49,7 @@ module.exports = auto(
      * @async
      * @param {string} account_id - The account ID
      * @param {string} namespace_id - The namespace ID
-     * @param {string} key_name - The key name
+     * @param {string} id - The key to store into
      * @param {string} value - The value to store
      * @returns {Promise<Object>} The KV response object
      */
@@ -66,7 +66,7 @@ module.exports = auto(
      * @async
      * @param {string} account_id - The account ID
      * @param {string} namespace_id - The namespace ID
-     * @param {string} key_name - The key name
+     * @param {string} id - The key to read from
      * @returns {Promise<Object>} The KV response object
      */
     read: method({
@@ -84,7 +84,7 @@ module.exports = auto(
      * @async
      * @param {string} account_id - The account ID
      * @param {string} namespace_id - The namespace ID
-     * @param {string} key_name - The key name
+     * @param {string} id - The key to delete
      * @returns {Promise<Object>} The KV response object
      */
     del: method({

--- a/lib/resources/EnterpriseZoneWorkersKV.js
+++ b/lib/resources/EnterpriseZoneWorkersKV.js
@@ -55,7 +55,7 @@ module.exports = auto(
      */
     add: method({
       method: 'PUT',
-      path: 'values/:key_name',
+      path: 'values/:id',
     }),
     /**
      * read allows for reading the contents of key in a namespace
@@ -71,7 +71,7 @@ module.exports = auto(
      */
     read: method({
       method: 'GET',
-      path: 'values/:key_name',
+      path: 'values/:id',
       json: false,
       contentType: 'text/plain',
     }),
@@ -89,7 +89,7 @@ module.exports = auto(
      */
     del: method({
       method: 'DELETE',
-      path: 'values/:key_name',
+      path: 'values/:id',
     }),
     /**
      * addMulti allows for creating multiple key-value pairs in a namespace


### PR DESCRIPTION
I noticed that the `EnterpriseZoneWorkersKV.add` call doesn't have the `key_name` argument listed in the docstring, which caused incorrect types to be created in the DefinitelyTyped repo / `@types/cloudflare` package: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/cloudflare/index.d.ts#L111

API docs: https://api.cloudflare.com/#workers-kv-namespace-write-key-value-pair

I've verified that the method works as expected when called with 4 arguments: 3rd argument becomes the `:id` parameter in the URL, and the 4th becomes PUT request's body.

For clarity's sake, I've also renamed `:id` positional arguments in paths to `:key_name`, to match docstrings and the API docs.

Corresponding PR to update DefinitelyTyped: TBA