### PR TITLE
adding support for Cloudflare Tunnel API

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ const proxy = require('./lib/proxy');
 /* eslint-disable global-require */
 const resources = {
   argoTunnels: require('./lib/resources/ArgoTunnels'),
+  cloudflareTunnels: require('./lib/resources/CloudflareTunnels'),
+  cloudflareTunnelConnections: require('./lib/resources/CloudflareTunnelConnections'),
+  cloudflareTunnelConfigurations: require('./lib/resources/CloudflareTunnelConfigurations'),
   dnsRecords: require('./lib/resources/DNSRecords'),
   enterpriseZoneWorkersScripts: require('./lib/resources/EnterpriseZoneWorkersScripts'),
   enterpriseZoneWorkersRoutes: require('./lib/resources/EnterpriseZoneWorkersRoutes'),

--- a/lib/resources/CloudflareTunnelConfigurations.js
+++ b/lib/resources/CloudflareTunnelConfigurations.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2014-present Cloudflare, Inc.
+
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+'use strict';
+
+const prototypal = require('es-class');
+const auto = require('autocreate');
+
+const Resource = require('../Resource');
+const method = require('../method');
+
+/**
+ * Cloudflare Tunnel Configurations represents the /accounts/:accountId/cfd_tunnel/:tunnel_id/configurations API endpoint.
+ *
+ * @class CloudflareTunnelConfigurations
+ * @hideconstructor
+ * @extends Resource
+ */
+module.exports = auto(
+  prototypal({
+    extends: Resource,
+    path: 'accounts/:accountId/cfd_tunnel/:tunnel_id/configurations',
+
+    includeBasic: ['read'],
+
+    /**
+     * edit allows for modification of the specified Cloudflare Tunnel Configuration
+     *
+     * @function edit
+     * @memberof CloudflareTunnelConfigurations
+     * @instance
+     * @async
+     * @param {string} accountId - The account ID
+     * @param {string} tunnel_id -  The Cloudflare Tunnel ID being modified
+     * @param {Object} configuration - The modified Cloudflare Tunnel Configuration object
+     * @returns {Promise<Object>} The Cloudflare Tunnel Configuration object.
+     */
+     edit: method({
+      method: 'PUT',
+      path: '',
+    }),
+    /**
+     * read allows for retrieving the specified Cloudflare Tunnel Configuration
+     *
+     * @function read
+     * @memberof CloudflareTunnelConfigurations
+     * @instance
+     * @async
+     * @param {string} accountId - The account ID
+     * @param {string} tunnel_id - The Cloudflare Tunnel ID
+     * @returns {Promise<Object>} The Cloudflare Tunnel Configuration object.
+     */
+  })
+);

--- a/lib/resources/CloudflareTunnelConnections.js
+++ b/lib/resources/CloudflareTunnelConnections.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2014-present Cloudflare, Inc.
+
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+'use strict';
+
+const prototypal = require('es-class');
+const auto = require('autocreate');
+
+const Resource = require('../Resource');
+
+/**
+ * Cloudflare Tunnel Connections represents the /accounts/:accountId/cfd_tunnel/:tunnel_id/connections API endpoint.
+ *
+ * @class CloudflareTunnelConnections
+ * @hideconstructor
+ * @extends Resource
+ */
+module.exports = auto(
+  prototypal({
+    extends: Resource,
+    path: 'accounts/:accountId/cfd_tunnel/:tunnel_id/connections',
+
+    includeBasic: ['browse', 'del'],
+
+    /**
+     * browse allows for listing all Cloudflare Tunnel Connections for a Cloudflare Tunnel
+     *
+     * @function browse
+     * @memberof CloudflareTunnelConnections
+     * @instance
+     * @async
+     * @param {string} accountId - The account ID
+     * @param {string} tunnel_id - The tunnel ID
+     * @returns {Promise<Object>} The Cloudflare Tunnel Connections response object.
+     */
+    /**
+     * del removes stale connection resources from a Cloudflare Tunnel
+     *
+     * @function del
+     * @memberof CloudflareTunnelConnections
+     * @instance
+     * @async
+     * @param {string} accountId - The account ID
+     * @param {string} tunnel_id - The tunnel ID
+     * @returns {Promise<Object>} The response object.
+     */
+  })
+);

--- a/lib/resources/CloudflareTunnels.js
+++ b/lib/resources/CloudflareTunnels.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2014-present Cloudflare, Inc.
+
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+'use strict';
+
+const prototypal = require('es-class');
+const auto = require('autocreate');
+
+const Resource = require('../Resource');
+const method = require('../method');
+
+/**
+ * Cloudflare Tunnels represents the /accounts/:accountId/cfd_tunnel API endpoint.
+ *
+ * @class CloudflareTunnels
+ * @hideconstructor
+ * @extends Resource
+ */
+module.exports = auto(
+  prototypal({
+    extends: Resource,
+    path: 'accounts/:accountId/cfd_tunnel',
+
+    includeBasic: ['browse', 'read', 'edit', 'add', 'del'],
+
+    /**
+     * token gets the Tunnel token for a previously created Cloudflare Tunnel
+     *
+     * @function clean
+     * @memberof ArgoTunnels
+     * @instance
+     * @async
+     * @param {string} accountId - The account ID
+     * @param {string} id - The tunnel ID to get the token of
+     * @returns {Promise<Object>} The response object.
+     */
+    token: method({
+        method: 'GET',
+        path: ':id/token',
+      }),
+    
+    /**
+     * browse allows for listing all Cloudflare Tunnels for an account
+     *
+     * @function browse
+     * @memberof CloudflareTunnels
+     * @instance
+     * @async
+     * @param {string} accountId - The account ID
+     * @returns {Promise<Object>} The Cloudflare Tunnels response object.
+     */
+    /**
+     * read allows for retrieving the specified Cloudflare Tunnel
+     *
+     * @function read
+     * @memberof CloudflareTunnels
+     * @instance
+     * @async
+     * @param {string} accountId - The account ID
+     * @param {string} id - The Cloudflare Tunnel ID
+     * @returns {Promise<Object>} The Cloudflare Tunnel object.
+     */
+    /**
+     * add allows for creating a new Cloudflare Tunnel for an account.
+     *
+     * @function add
+     * @memberof CloudflareTunnels
+     * @instance
+     * @async
+     * @param {string} accountId - The account ID
+     * @param {Object} tunnel - The new Cloudflare Tunnel object
+     * @returns {Promise<Object>} The created Cloudflare Tunnel object.
+     */
+    /**
+     * edit allows for modification of the specified Cloudflare Tunnel
+     *
+     * @function edit
+     * @memberof CloudflareTunnels
+     * @instance
+     * @async
+     * @param {string} accountId - The account ID
+     * @param {Object} tunnel - The updated Cloudflare Tunnel object
+     * @returns {Promise<Object>} The updated Cloudflare Tunnel object.
+     */
+    /**
+     * del allows for deleting the specified Tunnel
+     *
+     * @function del
+     * @memberof CloudflareTunnels
+     * @instance
+     * @async
+     * @param {string} accountId - The account ID
+     * @param {string} id - The Cloudflare Tunnel ID
+     * @returns {Promise<Object>} The deleted Cloudflare Tunnel object.
+     */
+  })
+);


### PR DESCRIPTION
Argo Tunnels API has been deprecated and will be removed February 4, 2024.  Cloudflare Tunnels API is the replacement.